### PR TITLE
VBLOCKS-1999: Upgraded implicit log4j dependency to fix security holes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.2</version>
+            <version>1.4.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There was a Log4J security hole fond in the dependencies for the test cases. Upgrading to the latest version of logback should resolve this issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
